### PR TITLE
Get Rating to recognize correct food ID after calling AddRecipe

### DIFF
--- a/ThePerfectPair/ThePerfectPair/DAL/FoodRepository.cs
+++ b/ThePerfectPair/ThePerfectPair/DAL/FoodRepository.cs
@@ -23,7 +23,7 @@ namespace ThePerfectPair.DAL
         _dbContext.SaveChanges();
         return GetLatestFood();
       }
-      return GetLatestFood();
+      return null;
     }
     public Food GetLatestFood()
     {

--- a/ThePerfectPair/ThePerfectPair/Migrations/20230329185826_update.Designer.cs
+++ b/ThePerfectPair/ThePerfectPair/Migrations/20230329185826_update.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ThePerfectPair.DAL;
 
@@ -11,9 +12,10 @@ using ThePerfectPair.DAL;
 namespace ThePerfectPair.Migrations
 {
     [DbContext(typeof(PerfectPairContext))]
-    partial class PerfectPairContextModelSnapshot : ModelSnapshot
+    [Migration("20230329185826_update")]
+    partial class update
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ThePerfectPair/ThePerfectPair/Migrations/20230329185826_update.cs
+++ b/ThePerfectPair/ThePerfectPair/Migrations/20230329185826_update.cs
@@ -1,0 +1,98 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ThePerfectPair.Migrations
+{
+    public partial class update : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Drinks_Categories_CategoryId",
+                table: "Drinks");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Ratings_Drinks_DrinkId",
+                table: "Ratings");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Ratings_Foods_FoodId",
+                table: "Ratings");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Ratings_DrinkId",
+                table: "Ratings");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Ratings_FoodId",
+                table: "Ratings");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "CategoryId",
+                table: "Drinks",
+                type: "int",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldNullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Drinks_Categories_CategoryId",
+                table: "Drinks",
+                column: "CategoryId",
+                principalTable: "Categories",
+                principalColumn: "CategoryId",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Drinks_Categories_CategoryId",
+                table: "Drinks");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "CategoryId",
+                table: "Drinks",
+                type: "int",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "int");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Ratings_DrinkId",
+                table: "Ratings",
+                column: "DrinkId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Ratings_FoodId",
+                table: "Ratings",
+                column: "FoodId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Drinks_Categories_CategoryId",
+                table: "Drinks",
+                column: "CategoryId",
+                principalTable: "Categories",
+                principalColumn: "CategoryId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Ratings_Drinks_DrinkId",
+                table: "Ratings",
+                column: "DrinkId",
+                principalTable: "Drinks",
+                principalColumn: "DrinkId",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Ratings_Foods_FoodId",
+                table: "Ratings",
+                column: "FoodId",
+                principalTable: "Foods",
+                principalColumn: "FoodId",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/ThePerfectPair/ThePerfectPair/appsettings.json
+++ b/ThePerfectPair/ThePerfectPair/appsettings.json
@@ -8,6 +8,6 @@
   "AllowedHosts": "*",
   "ConnectionStrings": {
     "PairingDb": //"Data Source=GB_BRICKS\\SQLEXPRESS;Initial Catalog=PerfectPairDb;Trusted_Connection=True;TrustServerCertificate=True;"
-    "Data Source=LAPTOP-V96QF1E9\\SQLEXPRESS;Initial Catalog=PerfectPairDb;Trusted_Connection=True;TrustServerCertificate=True;"
+    "Data Source=KTG16\\SQLEXPRESS;Initial Catalog=PerfectPairDb;Trusted_Connection=True;TrustServerCertificate=True;"
   }
 }

--- a/src/app/food-wine-pairing/pairing-list/pairing-list.component.ts
+++ b/src/app/food-wine-pairing/pairing-list/pairing-list.component.ts
@@ -27,6 +27,7 @@ export class PairingListComponent implements OnInit {
   FoodWinePair: any
   pairedWines: string[] = []
   WineFoodPair: any
+  newDbRecipe: any
   pairedFoods: string[] = []
   header: string = ""
 
@@ -39,7 +40,6 @@ export class PairingListComponent implements OnInit {
   randomFoodId: number = -1
   randomWineId: number = -1
   getLatestId: number = -1
-
   randomWine: any
   wineTitle: string = ""
 
@@ -88,8 +88,8 @@ export class PairingListComponent implements OnInit {
           imageUrl: this.recipeImage,
           linkUrl: this.recipeLink
         }
-        this.AddRecipe(newRecipe)
-
+        let newDbRecipe = this.AddRecipe(newRecipe);
+        this.getLatestId = this.newDbRecipe.Id;
       })
   }
 
@@ -117,9 +117,7 @@ export class PairingListComponent implements OnInit {
   }
 
   AddRecipe(newRecipe: INewRecipe) {
-    console.log(newRecipe)
     this.repositoryService.AddRecipeToDb(newRecipe).subscribe(
-
       () => {
         this.ngOnInit();
       }


### PR DESCRIPTION
This problem is that we get a rating from the user, send the rating to the back end to be written to the database, the database sends back the food id for us to use in the rating, but the food ID that we write to the rating table is one less than the correct ID.

I think I fixed this by assigning a variable to the new food object that we'll be creating when we call AddRecipe. That is a class-level variable so we can use that variable when we send the new rating to the DB.